### PR TITLE
Fix reordering methods

### DIFF
--- a/pytreex/core/node.py
+++ b/pytreex/core/node.py
@@ -465,11 +465,11 @@ class Ordered(object):
 
     def shift_after_node(self, other, without_children=False):
         "Shift one node after another in the ordering."
-        self.__shift_to_node(other, after=True)
+        self.__shift_to_node(other, after=True, without_children=without_children)
 
     def shift_before_node(self, other, without_children=False):
         "Shift one node before another in the ordering."
-        self.__shift_to_node(other, after=False)
+        self.__shift_to_node(other, after=False, without_children=without_children)
 
     def shift_before_subtree(self, other, without_children=False):
         """\
@@ -480,7 +480,7 @@ class Ordered(object):
         if len(subtree) <= 1 and self == other:
             return  # no point if self==other and there are no children
         self.__shift_to_node(subtree[0] == self and subtree[1] or subtree[0],
-                             after=False)
+                             after=False, without_children=without_children)
 
     def shift_after_subtree(self, other, without_children=False):
         """\
@@ -489,8 +489,8 @@ class Ordered(object):
         subtree = other.get_descendants(ordered=True, add_self=True)
         if len(subtree) <= 1 and self == other:
             return   # no point if self==other and there are no children
-        self.__shift_to_node(subtree[-1] == self
-                             and subtree[-2] or subtree[-1], after=True)
+        self.__shift_to_node(subtree[-1] == self and subtree[-2] or subtree[-1],
+                             after=True, without_children=without_children)
 
     def __shift_to_node(self, other, after, without_children=False):
         "Shift a node before or after another node in the ordering"

--- a/pytreex/core/node.py
+++ b/pytreex/core/node.py
@@ -482,17 +482,25 @@ class Ordered(object):
         Shift one node before the whole subtree of another node
         in the ordering.
         """
-        subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
-        self.__shift_to_node(subtree[0] == self and subtree[1] or subtree[0],
-                             after=False, without_children=without_children)
+        if without_children:
+            subtree = [ node for node in other.get_descendants(ordered=True, add_self=True) if node != self]
+        else:
+            subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
+        if len(subtree)==0:
+            return
+        self.__shift_to_node(subtree[0], after=False, without_children=without_children)
 
     def shift_after_subtree(self, other, without_children=False):
         """\
         Shift one node after the whole subtree of another node in the ordering.
         """
-        subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
-        self.__shift_to_node(subtree[-1] == self and subtree[-2] or subtree[-1],
-                             after=True, without_children=without_children)
+        if without_children:
+            subtree = [ node for node in other.get_descendants(ordered=True, add_self=True) if node != self]
+        else:
+            subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
+        if len(subtree)==0:
+            return
+        self.__shift_to_node(subtree[-1], after=True, without_children=without_children)
 
     def __shift_to_node(self, other, after, without_children=False):
         "Shift a node before or after another node in the ordering"

--- a/pytreex/core/node.py
+++ b/pytreex/core/node.py
@@ -321,12 +321,18 @@ class Node(object):
         return getattr(sys.modules[__name__],
                        self.__class__.__name__)(data=data, parent=self)
 
-    def remove(self):
+    def remove(self, fix_order=True):
         "Remove the node from the tree."
+        root = self.root # backup, self.root will not be reliable (why?)
         for child in self.get_children():
-            child.remove()
+            child.remove(fix_order=False)
         self.parent = None
         self.document.remove_node(self.id)
+
+        # We need to normalize ordering, so there are no gaps
+        if fix_order and isinstance(self, Ordered):
+            for new_ord, node in enumerate(root.get_descendants(add_self=True, ordered=True)):
+                node.ord = new_ord
 
     def is_descendant_of(self, another_node):
         "Is this node a descendant of another node?"

--- a/pytreex/core/node.py
+++ b/pytreex/core/node.py
@@ -483,8 +483,6 @@ class Ordered(object):
         in the ordering.
         """
         subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
-        if len(subtree) <= 1 and self == other:
-            return  # no point if self==other and there are no children
         self.__shift_to_node(subtree[0] == self and subtree[1] or subtree[0],
                              after=False, without_children=without_children)
 
@@ -493,13 +491,13 @@ class Ordered(object):
         Shift one node after the whole subtree of another node in the ordering.
         """
         subtree = other.get_descendants(ordered=True, add_self=True, except_subtree=self)
-        if len(subtree) <= 1 and self == other:
-            return   # no point if self==other and there are no children
         self.__shift_to_node(subtree[-1] == self and subtree[-2] or subtree[-1],
                              after=True, without_children=without_children)
 
     def __shift_to_node(self, other, after, without_children=False):
         "Shift a node before or after another node in the ordering"
+        if self==other:
+            return
         if not without_children and other.is_descendant_of(self):
             raise RuntimeException('{} is a descendant of {}. Maybe you have forgotten without_children=True.'.format(other.id, self.id))
         all_nodes = self.root.get_descendants(ordered=True, add_self=True)


### PR DESCRIPTION
Implementation of the reordering (shift_*) methods is tricky.
Now, Pytreex gives exactly the same output files as Treex in the https://github.com/martinpopel/newtreex benchmark, so I hope I fixed most of the bugs.
